### PR TITLE
Style  add semicolons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    #- name: Lint
-    #  run:  npm run lint
+    - name: Lint
+      run:  npm run lint
 
     - name: Code Climate Coverage Action
       uses: paambaati/codeclimate-action@v2.7.5

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -9,9 +9,9 @@ describe('`updateQuality`', () => {
 
   it('Updates the quality of aged brie', () => {
     const brie = new Item('Aged Brie', 7, 2);
-    const brieExpired = new Item('Aged Brie', -1, 10)
-    const brieHighestQuality = new Item('Aged Brie', -1, 50)
-    updateQuality([brie, brieExpired, brieHighestQuality])
+    const brieExpired = new Item('Aged Brie', -1, 10);
+    const brieHighestQuality = new Item('Aged Brie', -1, 50);
+    updateQuality([brie, brieExpired, brieHighestQuality]);
     expect(brie.quality).toBe(3);
     expect(brieExpired.quality).toBe(12);
     expect(brieHighestQuality.quality).toBe(50);
@@ -21,45 +21,45 @@ describe('`updateQuality`', () => {
     const sulfuras = new Item('Sulfuras, Hand of Ragnaros', 0, 80);
     updateQuality([sulfuras]);
     expect(sulfuras.quality).toBe(80);
-  })
+  });
 
   it('Updates the quality of backstage passes', () => {
-    const pass = new Item('Backstage passes to a TAFKAL80ETC concert', 11, 10)
-    const passTenDays = new Item('Backstage passes to a TAFKAL80ETC concert', 10, 8)
-    const passFiveDays = new Item('Backstage passes to a TAFKAL80ETC concert', 5, 15)
-    const passMaximumQuality = new Item('Backstage passes to a TAFKAL80ETC concert', 1, 50)
-    const passPostConcert = new Item('Backstage passes to a TAFKAL80ETC concert', -1, 50)
-    const passMinimumQuality = new Item('Backstage passes to a TAFKAL80ETC concert', -1, 0)
-    updateQuality([pass, passTenDays, passFiveDays, passMaximumQuality, passPostConcert, passMinimumQuality])
-    expect(pass.quality).toBe(11)
-    expect(passTenDays.quality).toBe(10)
-    expect(passFiveDays.quality).toBe(18)
-    expect(passMaximumQuality.quality).toBe(50)
-    expect(passPostConcert.quality).toBe(0)
-    expect(passMinimumQuality.quality).toBe(0)
-  })
+    const pass = new Item('Backstage passes to a TAFKAL80ETC concert', 11, 10);
+    const passTenDays = new Item('Backstage passes to a TAFKAL80ETC concert', 10, 8);
+    const passFiveDays = new Item('Backstage passes to a TAFKAL80ETC concert', 5, 15);
+    const passMaximumQuality = new Item('Backstage passes to a TAFKAL80ETC concert', 1, 50);
+    const passPostConcert = new Item('Backstage passes to a TAFKAL80ETC concert', -1, 50);
+    const passMinimumQuality = new Item('Backstage passes to a TAFKAL80ETC concert', -1, 0);
+    updateQuality([pass, passTenDays, passFiveDays, passMaximumQuality, passPostConcert, passMinimumQuality]);
+    expect(pass.quality).toBe(11);
+    expect(passTenDays.quality).toBe(10);
+    expect(passFiveDays.quality).toBe(18);
+    expect(passMaximumQuality.quality).toBe(50);
+    expect(passPostConcert.quality).toBe(0);
+    expect(passMinimumQuality.quality).toBe(0);
+  });
 
   it('Updates the quality of normal items', () => {
-    const vest = new Item('+5 Dexterity Vest', 5, 10)
-    const oldVest = new Item('+5 Dexterity Vest', -1, 5)
-    const minimumQualityVest = new Item('+5 Dexterity Vest', -5, 0)
-    const elixir = new Item('Elixir of the Mongoose', 3, 50)
-    const oldElixir = new Item('Elixir of the Mongoose', 0, 28)
-    const minimumQualityElixir = new Item('Elixir of the Mongoose', 0, 0)
-    updateQuality([vest, oldVest, minimumQualityVest, elixir, oldElixir, minimumQualityElixir])
-    expect(vest.quality).toBe(9)
-    expect(oldVest.quality).toBe(3)
-    expect(minimumQualityVest.quality).toBe(0)
-    expect(elixir.quality).toBe(49)
-    expect(oldElixir.quality).toBe(26)
-    expect(minimumQualityElixir.quality).toBe(0)
-  })
+    const vest = new Item('+5 Dexterity Vest', 5, 10);
+    const oldVest = new Item('+5 Dexterity Vest', -1, 5);
+    const minimumQualityVest = new Item('+5 Dexterity Vest', -5, 0);
+    const elixir = new Item('Elixir of the Mongoose', 3, 50);
+    const oldElixir = new Item('Elixir of the Mongoose', 0, 28);
+    const minimumQualityElixir = new Item('Elixir of the Mongoose', 0, 0);
+    updateQuality([vest, oldVest, minimumQualityVest, elixir, oldElixir, minimumQualityElixir]);
+    expect(vest.quality).toBe(9);
+    expect(oldVest.quality).toBe(3);
+    expect(minimumQualityVest.quality).toBe(0);
+    expect(elixir.quality).toBe(49);
+    expect(oldElixir.quality).toBe(26);
+    expect(minimumQualityElixir.quality).toBe(0);
+  });
 
   it.skip('Updates the quality of conjured items', () => {
-    const cake = new Item('Conjured Mana Cake', 5, 10)
-    const oldCake = new Item('Conjured Mana Cake', -1, 10)
-    updateQuality([cake, oldCake])
-    expect(cake.quality).toBe(8)
-    expect(oldCake.quality).toBe(6)
-  })
+    const cake = new Item('Conjured Mana Cake', 5, 10);
+    const oldCake = new Item('Conjured Mana Cake', -1, 10);
+    updateQuality([cake, oldCake]);
+    expect(cake.quality).toBe(8);
+    expect(oldCake.quality).toBe(6);
+  });
 });

--- a/src/gilded_rose.spec.js
+++ b/src/gilded_rose.spec.js
@@ -30,7 +30,8 @@ describe('`updateQuality`', () => {
     const passMaximumQuality = new Item('Backstage passes to a TAFKAL80ETC concert', 1, 50);
     const passPostConcert = new Item('Backstage passes to a TAFKAL80ETC concert', -1, 50);
     const passMinimumQuality = new Item('Backstage passes to a TAFKAL80ETC concert', -1, 0);
-    updateQuality([pass, passTenDays, passFiveDays, passMaximumQuality, passPostConcert, passMinimumQuality]);
+    updateQuality([pass, passTenDays, passFiveDays, passMaximumQuality,
+      passPostConcert, passMinimumQuality]);
     expect(pass.quality).toBe(11);
     expect(passTenDays.quality).toBe(10);
     expect(passFiveDays.quality).toBe(18);


### PR DESCRIPTION
## Description
Fixed some style issues with the linter: added semicolons and broke up a long line.
Re-enabled linter after fixing style issues.

## Spec

See Issue: [FSA2021-28](https://sparkbox.atlassian.net/browse/FSA2021-28)

## Validation

- [✔️ ] This PR has code changes, and our linters still pass.
- [ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down all related branches.
1. Navigate to `npm run lint`
